### PR TITLE
Fix deprecation warning pandas.io.json.json_normalize

### DIFF
--- a/flat_table/_norm.py
+++ b/flat_table/_norm.py
@@ -50,7 +50,7 @@ def to_columns(series):
     ds = series.copy()
     # rows with values
     ds_withvalues = ds[pd.notna(ds)]
-    df_withvalues = pd.io.json.json_normalize(ds_withvalues)
+    df_withvalues = pd.json_normalize(ds_withvalues)
     df_withvalues.index = ds_withvalues.index
 
     # rows with nans


### PR DESCRIPTION
Using pandas.json_normalize instead of pandas.io.json.json_normalize to fix deprecation warning.